### PR TITLE
Don't specify registry for base image.

### DIFF
--- a/2.0/Dockerfile.rhel7
+++ b/2.0/Dockerfile.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/openshift3/jenkins-slave-base-rhel7
+FROM openshift3/jenkins-slave-base-rhel7
 
 # Labels consumed by Red Hat build service
 LABEL com.redhat.component="rh-dotnet20-jenkins-slave-docker" \


### PR DESCRIPTION
Specifying the registry makes the image fail to build in the internal build system.