### PR TITLE
Add explicit rm for yum cache to reduce image size.

### DIFF
--- a/2.0/Dockerfile
+++ b/2.0/Dockerfile
@@ -24,13 +24,12 @@ ENV DOTNET_CORE_VERSION=2.0 \
 COPY contrib/bin/scl_enable /usr/local/bin/scl_enable
 
 # Install
-# The 'rm -rf /var/cache/yum' line is there to clean out orphaned yum cache files,
-# which can be quite large in size.
 RUN yum install -y centos-release-dotnet centos-release-scl-rh && \
     INSTALL_PKGS="rh-dotnet20 rh-nodejs6-npm" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y && \
+    # yum cache files may still exist (and quite large in size)
     rm -rf /var/cache/yum/*
 
 RUN chown -R 1001:0 $HOME && \

--- a/2.0/Dockerfile
+++ b/2.0/Dockerfile
@@ -28,7 +28,8 @@ RUN yum install -y centos-release-dotnet centos-release-scl-rh && \
     INSTALL_PKGS="rh-dotnet20 rh-nodejs6-npm" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
-    yum clean all -y
+    yum clean all -y && \
+    rm -rf /var/cache/yum/*
 
 RUN chown -R 1001:0 $HOME && \
     chmod -R g+rw $HOME

--- a/2.0/Dockerfile
+++ b/2.0/Dockerfile
@@ -29,7 +29,7 @@ RUN yum install -y centos-release-dotnet centos-release-scl-rh && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y && \
-    rm -rf /var/cache/yum/*
+    rm -rf /var/cache/yum/* # Cache files may be left over (and quite large in size)
 
 RUN chown -R 1001:0 $HOME && \
     chmod -R g+rw $HOME

--- a/2.0/Dockerfile
+++ b/2.0/Dockerfile
@@ -24,12 +24,14 @@ ENV DOTNET_CORE_VERSION=2.0 \
 COPY contrib/bin/scl_enable /usr/local/bin/scl_enable
 
 # Install
+# The 'rm -rf /var/cache/yum' line is there to clean out orphaned yum cache files,
+# which can be quite large in size.
 RUN yum install -y centos-release-dotnet centos-release-scl-rh && \
     INSTALL_PKGS="rh-dotnet20 rh-nodejs6-npm" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y && \
-    rm -rf /var/cache/yum/* # Cache files may be left over (and quite large in size)
+    rm -rf /var/cache/yum/*
 
 RUN chown -R 1001:0 $HOME && \
     chmod -R g+rw $HOME

--- a/2.0/Dockerfile
+++ b/2.0/Dockerfile
@@ -29,7 +29,7 @@ RUN yum install -y centos-release-dotnet centos-release-scl-rh && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y && \
-    # yum cache files may still exist (and quite large in size)
+# yum cache files may still exist (and quite large in size)
     rm -rf /var/cache/yum/*
 
 RUN chown -R 1001:0 $HOME && \

--- a/2.0/Dockerfile.rhel7
+++ b/2.0/Dockerfile.rhel7
@@ -24,14 +24,13 @@ ENV DOTNET_CORE_VERSION=2.0 \
 COPY contrib/bin/scl_enable /usr/local/bin/scl_enable
 
 # Install
-# The 'rm -rf /var/cache/yum' line is there to clean out orphaned yum cache files,
-# # which can be quite large in size.
 RUN INSTALL_PKGS="rh-dotnet20 rh-nodejs6-npm" && \
     yum install -y --setopt=tsflags=nodocs --disablerepo=\* \
       --enablerepo=rhel-7-server-rpms,rhel-server-rhscl-7-rpms,rhel-7-server-dotnet-rpms \
       $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y && \
+    # yum cache files may still exist (and quite large in size)
     rm -rf /var/cache/yum/*
 
 RUN chown -R 1001:0 $HOME && \

--- a/2.0/Dockerfile.rhel7
+++ b/2.0/Dockerfile.rhel7
@@ -24,13 +24,15 @@ ENV DOTNET_CORE_VERSION=2.0 \
 COPY contrib/bin/scl_enable /usr/local/bin/scl_enable
 
 # Install
+# The 'rm -rf /var/cache/yum' line is there to clean out orphaned yum cache files,
+# # which can be quite large in size.
 RUN INSTALL_PKGS="rh-dotnet20 rh-nodejs6-npm" && \
     yum install -y --setopt=tsflags=nodocs --disablerepo=\* \
       --enablerepo=rhel-7-server-rpms,rhel-server-rhscl-7-rpms,rhel-7-server-dotnet-rpms \
       $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y && \
-    rm -rf /var/cache/yum/* # Cache files may be left over (and quite large in size)
+    rm -rf /var/cache/yum/*
 
 RUN chown -R 1001:0 $HOME && \
     chmod -R g+rw $HOME

--- a/2.0/Dockerfile.rhel7
+++ b/2.0/Dockerfile.rhel7
@@ -30,7 +30,7 @@ RUN INSTALL_PKGS="rh-dotnet20 rh-nodejs6-npm" && \
       $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y && \
-    rm -rf /var/cache/yum/*
+    rm -rf /var/cache/yum/* # Cache files may be left over (and quite large in size)
 
 RUN chown -R 1001:0 $HOME && \
     chmod -R g+rw $HOME

--- a/2.0/Dockerfile.rhel7
+++ b/2.0/Dockerfile.rhel7
@@ -29,7 +29,8 @@ RUN INSTALL_PKGS="rh-dotnet20 rh-nodejs6-npm" && \
       --enablerepo=rhel-7-server-rpms,rhel-server-rhscl-7-rpms,rhel-7-server-dotnet-rpms \
       $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
-    yum clean all -y
+    yum clean all -y && \
+    rm -rf /var/cache/yum/*
 
 RUN chown -R 1001:0 $HOME && \
     chmod -R g+rw $HOME

--- a/2.0/Dockerfile.rhel7
+++ b/2.0/Dockerfile.rhel7
@@ -30,7 +30,7 @@ RUN INSTALL_PKGS="rh-dotnet20 rh-nodejs6-npm" && \
       $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y && \
-    # yum cache files may still exist (and quite large in size)
+# yum cache files may still exist (and quite large in size)
     rm -rf /var/cache/yum/*
 
 RUN chown -R 1001:0 $HOME && \


### PR DESCRIPTION
Turns out the yum clear all -y line doesn't clear out all the cache files. I believe this is because we disable the repos and then enable them manually. Explicitly removing the cache saves ~350 MB in the image.

Note: the centos image doesn't have this problem, assumidly because it doesn't disable repos like the rhel image does, but I went ahead and added the lines for consistency. If anyone disagrees with that, just let me know and I'll remove the changes to the centos image.