### PR TITLE
Trim nodejs dependencies

### DIFF
--- a/2.0/Dockerfile
+++ b/2.0/Dockerfile
@@ -28,6 +28,8 @@ RUN yum install -y centos-release-dotnet centos-release-scl-rh && \
     INSTALL_PKGS="rh-dotnet20 rh-nodejs6-npm" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+# trim nodejs dependencies to reduce image size and to avoid rebuilds on kernel CVEs.
+    rpm -e --nodeps glibc-headers glibc-devel gcc gcc-c++ kernel-headers && \
     yum clean all -y && \
 # yum cache files may still exist (and quite large in size)
     rm -rf /var/cache/yum/*

--- a/2.0/Dockerfile.rhel7
+++ b/2.0/Dockerfile.rhel7
@@ -29,6 +29,8 @@ RUN INSTALL_PKGS="rh-dotnet20 rh-nodejs6-npm" && \
       --enablerepo=rhel-7-server-rpms,rhel-server-rhscl-7-rpms,rhel-7-server-dotnet-rpms \
       $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+# trim nodejs dependencies to reduce image size and to avoid rebuilds on kernel CVEs.
+    rpm -e --nodeps glibc-headers glibc-devel gcc gcc-c++ kernel-headers && \
     yum clean all -y && \
 # yum cache files may still exist (and quite large in size)
     rm -rf /var/cache/yum/*


### PR DESCRIPTION
This reduces image size and avoids having to respin the images on kernel CVEs.